### PR TITLE
Add state management for decals

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,12 +1,18 @@
 import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js';
 import { OrbitControls } from 'https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/controls/OrbitControls.js';
 import { GLTFLoader } from 'https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/loaders/GLTFLoader.js';
+import { DecalGeometry } from 'https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/geometries/DecalGeometry.js';
 
 const scene = new THREE.Scene();
 const camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 100);
 const renderer = new THREE.WebGLRenderer({ canvas: document.getElementById('c'), antialias: true });
 renderer.setSize(window.innerWidth, window.innerHeight);
 renderer.setPixelRatio(window.devicePixelRatio);
+
+const raycaster = new THREE.Raycaster();
+const mouse = new THREE.Vector2();
+let model;
+let decalMesh;
 
 const ambientLight = new THREE.AmbientLight(0xffffff, 0.6);
 scene.add(ambientLight);
@@ -22,7 +28,7 @@ controls.update();
 
 const loader = new GLTFLoader();
 loader.load('./assets/model.glb', (gltf) => {
-    const model = gltf.scene;
+    model = gltf.scene;
     scene.add(model);
 }, undefined, (error) => {
     console.error('An error happened', error);
@@ -34,6 +40,42 @@ function onWindowResize() {
     renderer.setSize(window.innerWidth, window.innerHeight);
 }
 window.addEventListener('resize', onWindowResize);
+window.addEventListener('pointerdown', onPointerDown);
+
+function onPointerDown(event) {
+    mouse.x = (event.clientX / window.innerWidth) * 2 - 1;
+    mouse.y = -(event.clientY / window.innerHeight) * 2 + 1;
+
+    raycaster.setFromCamera(mouse, camera);
+
+    if (!model) return;
+
+    const intersects = raycaster.intersectObjects([model], true);
+    console.log(intersects);
+
+    if (intersects.length > 0) {
+        if (decalMesh) {
+            scene.remove(decalMesh);
+        }
+
+        const hit = intersects[0];
+        const up = new THREE.Vector3(0, 0, 1);
+        const quaternion = new THREE.Quaternion().setFromUnitVectors(up, hit.face.normal);
+        const orientation = new THREE.Euler().setFromQuaternion(quaternion);
+        const decalSize = new THREE.Vector3(0.1, 0.1, 0.1);
+        const decalGeometry = new DecalGeometry(hit.object, hit.point, orientation, decalSize);
+        const decalMaterial = new THREE.MeshStandardMaterial({
+            color: 0xff0000,
+            transparent: true,
+            depthTest: false,
+            polygonOffset: true,
+            polygonOffsetFactor: -4,
+            opacity: 0.8
+        });
+        decalMesh = new THREE.Mesh(decalGeometry, decalMaterial);
+        scene.add(decalMesh);
+    }
+}
 
 function animate() {
     requestAnimationFrame(animate);


### PR DESCRIPTION
## Summary
- track the current decal mesh
- remove the prior decal before adding a new one
- use a transparent decal material to avoid z-fighting

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6871501239dc8323bf8b0b459d52585f