### PR TITLE
Fix control panel overlay placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,9 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <canvas id="c"></canvas>
+    <div id="canvas-container">
+        <canvas id="c"></canvas>
+    </div>
     <div id="control-panel" class="panel">
         <label>Width
             <input type="range" id="width" min="0.05" max="1" step="0.01" value="0.2">

--- a/style.css
+++ b/style.css
@@ -1,5 +1,16 @@
 body { margin: 0; overflow: hidden; }
-#c { width: 100%; height: 100vh; display: block; }
+
+#canvas-container {
+  position: relative;
+  width: 100%;
+  height: 100vh;
+}
+
+#c {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
 
 #control-panel {
   position: absolute;
@@ -8,6 +19,7 @@ body { margin: 0; overflow: hidden; }
   padding: 10px;
   background: rgba(255, 255, 255, 0.8);
   border-radius: 4px;
+  z-index: 10;
   display: none;
 }
 

--- a/tattoo-app/index.html
+++ b/tattoo-app/index.html
@@ -8,7 +8,9 @@
     <link rel="stylesheet" href="style.css">
   </head>
   <body>
-    <canvas id="c"></canvas>
+    <div id="canvas-container">
+      <canvas id="c"></canvas>
+    </div>
     <div id="control-panel" class="panel">
       <label>Width
         <input type="range" id="width" min="0.05" max="1" step="0.01" value="0.2" />

--- a/tattoo-app/style.css
+++ b/tattoo-app/style.css
@@ -3,9 +3,15 @@ body {
   overflow: hidden;
 }
 
-#c {
+#canvas-container {
+  position: relative;
   width: 100%;
   height: 100vh;
+}
+
+#c {
+  width: 100%;
+  height: 100%;
   display: block;
 }
 
@@ -16,6 +22,7 @@ body {
   padding: 10px;
   background: rgba(255, 255, 255, 0.8);
   border-radius: 4px;
+  z-index: 10;
   display: none;
 }
 


### PR DESCRIPTION
## Summary
- wrap canvas in a container so control panel isn't inside canvas
- style container and ensure panel overlays canvas

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm test` in `tattoo-app` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6871b864115c832394c570f05e054856