### PR TITLE
Implement panel layout and remove lil-gui

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 ---
 
 ### Table of Contents
+
 1.  [The Vision](#the-vision)
 2.  [Core Features](#core-features)
 3.  [Technology](#technology)
@@ -19,48 +20,53 @@
 
 The journey to a new tattoo should be exciting, but the initial consultation is often a point of friction.
 
-*   **For Artists:** The challenge lies in deciphering vague descriptions, leading to endless emails and potential misunderstandings.
-*   **For Clients:** The difficulty comes from trying to articulate a visual idea with words, creating uncertainty and a fear of not being heard.
+- **For Artists:** The challenge lies in deciphering vague descriptions, leading to endless emails and potential misunderstandings.
+- **For Clients:** The difficulty comes from trying to articulate a visual idea with words, creating uncertainty and a fear of not being heard.
 
 **Digital Canvas solves this.** It replaces ambiguity with a clear, shared visual reference. By allowing clients to create a simple mock-up of their idea, it fosters a more professional, efficient, and collaborative dialogue, ensuring both artist and client begin the creative process aligned and with total confidence.
 
 ## Core Features
 
-*   **Interactive 3D Canvas:** A clean, minimalist 3D model that can be easily rotated, panned, and zoomed to view any part of the body.
-*   **Click-to-Place Simplicity:** Just click on the model to place a visual placeholder for your tattoo idea.
-*   **Real-time Design Controls:** Use a simple and clean UI to instantly adjust the placeholder's:
-    *   **Width & Height:** To get the scale just right.
-    *   **Rotation:** To match the flow of the body.
-*   **Export Your Vision:** With a single click, save the final placement as a high-quality PNG image, perfect for attaching to a booking form or email.
+- **Interactive 3D Canvas:** A clean, minimalist 3D model that can be easily rotated, panned, and zoomed to view any part of the body.
+- **Two-Column Layout:** The viewport sits beside a persistent control panel for a more professional workflow.
+- **Click-to-Place Simplicity:** Just click on the model to place a visual placeholder for your tattoo idea.
+- **Real-time Design Controls:** Use a simple and clean UI to instantly adjust the placeholder's:
+  - **Width & Height:** To get the scale just right.
+  - **Rotation:** To match the flow of the body.
+- **Export Your Vision:** With a single click, save the final placement as a high-quality PNG image, perfect for attaching to a booking form or email.
 
 ## Technology
 
 This tool is built with modern, lightweight web technologies to ensure it is fast, accessible, and runs smoothly in any modern browser.
 
-*   **Core Rendering:** [Three.js](https://threejs.org/)
-*   **Application Logic:** Vanilla JavaScript (ESM)
-*   **Build Tooling:** [Vite](https://vitejs.dev/)
+- **Core Rendering:** [Three.js](https://threejs.org/)
+- **Application Logic:** Vanilla JavaScript (ESM)
+- **Build Tooling:** [Vite](https://vitejs.dev/)
 
 ## Getting Started
 
 To run this project locally, you will need [Node.js](https://nodejs.org/) installed.
 
 1.  **Clone the repository:**
+
     ```bash
     git clone https://github.com/your-username/digital-canvas.git
     ```
 
 2.  **Navigate to the project directory:**
+
     ```bash
     cd digital-canvas
     ```
 
 3.  **Install dependencies:**
+
     ```bash
     npm install
     ```
 
 4.  **Run the development server:**
+
     ```bash
     npm run dev
     ```
@@ -71,7 +77,7 @@ To run this project locally, you will need [Node.js](https://nodejs.org/) instal
 
 This prototype is just the beginning. The vision for Digital Canvas extends to a full suite of tools designed to streamline the entire tattoo process. Future enhancements include:
 
-*   **Direct Booking Form Integration:** Embed the tool directly into artist websites.
-*   **Diverse Body Models:** Offer a selection of body types for better personalization.
-*   **Reference Image Uploads:** Allow users to project their own rough sketches onto the model.
-*   **Saved Sessions & Shareable Links:** Let users save their work and share a live, interactive 3D link with their artist.
+- **Direct Booking Form Integration:** Embed the tool directly into artist websites.
+- **Diverse Body Models:** Offer a selection of body types for better personalization.
+- **Reference Image Uploads:** Allow users to project their own rough sketches onto the model.
+- **Saved Sessions & Shareable Links:** Let users save their work and share a live, interactive 3D link with their artist.

--- a/tattoo-app/index.html
+++ b/tattoo-app/index.html
@@ -1,16 +1,52 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Digital Canvas (Vite)</title>
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <div id="app">
+    <div id="app" class="layout">
       <div id="canvas-container">
         <canvas id="c"></canvas>
+      </div>
+      <div id="control-panel" class="panel">
+        <h2>Controls</h2>
+        <label
+          >Width
+          <input
+            type="range"
+            id="width"
+            min="0.05"
+            max="1"
+            step="0.01"
+            value="0.2"
+          />
+        </label>
+        <label
+          >Height
+          <input
+            type="range"
+            id="height"
+            min="0.05"
+            max="1"
+            step="0.01"
+            value="0.2"
+          />
+        </label>
+        <label
+          >Rotation
+          <input
+            type="range"
+            id="rotation"
+            min="-3.14"
+            max="3.14"
+            step="0.01"
+            value="0"
+          />
+        </label>
       </div>
     </div>
     <script type="module" src="/main.js"></script>

--- a/tattoo-app/main.js
+++ b/tattoo-app/main.js
@@ -1,14 +1,21 @@
-import * as THREE from 'three';
-import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
-import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
-import { DecalGeometry } from 'three/examples/jsm/geometries/DecalGeometry.js';
-import GUI from 'lil-gui';
+import * as THREE from "three";
+import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
+import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
+import { DecalGeometry } from "three/examples/jsm/geometries/DecalGeometry.js";
 
 // Basic Setup
 const scene = new THREE.Scene();
 scene.background = new THREE.Color(0xf0f0f0); // Light grey background
-const camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 100);
-const renderer = new THREE.WebGLRenderer({ canvas: document.querySelector('#c'), antialias: true });
+const camera = new THREE.PerspectiveCamera(
+  45,
+  window.innerWidth / window.innerHeight,
+  0.1,
+  100,
+);
+const renderer = new THREE.WebGLRenderer({
+  canvas: document.querySelector("#c"),
+  antialias: true,
+});
 renderer.setSize(window.innerWidth, window.innerHeight);
 renderer.setPixelRatio(window.devicePixelRatio);
 
@@ -31,19 +38,32 @@ const mouse = new THREE.Vector2();
 let model;
 let decalMesh;
 
-// lil-gui parameters
+// UI parameters
 const params = {
   width: 0.2,
   height: 0.2,
-  rotation: 0
+  rotation: 0,
 };
 
-const gui = new GUI();
-gui.add(params, 'width', 0.05, 1.0).onChange(updateFromGui);
-gui.add(params, 'height', 0.05, 1.0).onChange(updateFromGui);
-gui.add(params, 'rotation', -3.14, 3.14).onChange(updateFromGui);
+// HTML elements
+const widthSlider = document.getElementById("width");
+const heightSlider = document.getElementById("height");
+const rotationSlider = document.getElementById("rotation");
 
-function updateFromGui() {
+widthSlider.addEventListener("input", updateFromUI);
+heightSlider.addEventListener("input", updateFromUI);
+rotationSlider.addEventListener("input", updateFromUI);
+
+/**
+ * Update the decal mesh based on current slider values.
+ *
+ * @returns {void}
+ */
+function updateFromUI() {
+  params.width = parseFloat(widthSlider.value);
+  params.height = parseFloat(heightSlider.value);
+  params.rotation = parseFloat(rotationSlider.value);
+
   if (decalMesh) {
     decalMesh.scale.x = params.width;
     decalMesh.scale.y = params.height;
@@ -54,66 +74,73 @@ function updateFromGui() {
 // Load Model
 const loader = new GLTFLoader();
 loader.load(
-    '/assets/model.glb', // Path relative to the 'public' folder
-    (gltf) => {
-        model = gltf.scene;
-        scene.add(model);
-        console.log("Model loaded successfully.");
-    },
-    undefined,
-    (error) => {
-        console.error('An error happened loading the model', error);
-    }
+  "/assets/model.glb", // Path relative to the 'public' folder
+  (gltf) => {
+    model = gltf.scene;
+    scene.add(model);
+    console.log("Model loaded successfully.");
+  },
+  undefined,
+  (error) => {
+    console.error("An error happened loading the model", error);
+  },
 );
 
 // Event Listeners
-window.addEventListener('resize', () => {
-    camera.aspect = window.innerWidth / window.innerHeight;
-    camera.updateProjectionMatrix();
-    renderer.setSize(window.innerWidth, window.innerHeight);
+window.addEventListener("resize", () => {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
 });
 
-window.addEventListener('pointerdown', (event) => {
-    mouse.x = (event.clientX / window.innerWidth) * 2 - 1;
-    mouse.y = -(event.clientY / window.innerHeight) * 2 + 1;
-    raycaster.setFromCamera(mouse, camera);
+window.addEventListener("pointerdown", (event) => {
+  mouse.x = (event.clientX / window.innerWidth) * 2 - 1;
+  mouse.y = -(event.clientY / window.innerHeight) * 2 + 1;
+  raycaster.setFromCamera(mouse, camera);
 
-    if (!model) return;
+  if (!model) return;
 
-    const intersects = raycaster.intersectObject(model, true);
+  const intersects = raycaster.intersectObject(model, true);
 
-    if (intersects.length > 0) {
-        if (decalMesh) {
-            scene.remove(decalMesh);
-        }
-        const hit = intersects[0];
-        const up = new THREE.Vector3(0, 0, 1);
-        const quaternion = new THREE.Quaternion().setFromUnitVectors(up, hit.face.normal);
-        const orientation = new THREE.Euler().setFromQuaternion(quaternion);
-        const decalSize = new THREE.Vector3(0.1, 0.1, 0.1);
-        const decalGeometry = new DecalGeometry(hit.object, hit.point, orientation, decalSize);
-        const decalMaterial = new THREE.MeshStandardMaterial({
-            color: 0xff0000,
-            transparent: true,
-            depthTest: false,
-            polygonOffset: true,
-            polygonOffsetFactor: -4,
-            opacity: 0.8
-        });
-        decalMesh = new THREE.Mesh(decalGeometry, decalMaterial);
-        decalMesh.scale.x = params.width;
-        decalMesh.scale.y = params.height;
-        decalMesh.rotation.z = params.rotation;
-        scene.add(decalMesh);
-        updateFromGui();
+  if (intersects.length > 0) {
+    if (decalMesh) {
+      scene.remove(decalMesh);
     }
+    const hit = intersects[0];
+    const up = new THREE.Vector3(0, 0, 1);
+    const quaternion = new THREE.Quaternion().setFromUnitVectors(
+      up,
+      hit.face.normal,
+    );
+    const orientation = new THREE.Euler().setFromQuaternion(quaternion);
+    const decalSize = new THREE.Vector3(0.1, 0.1, 0.1);
+    const decalGeometry = new DecalGeometry(
+      hit.object,
+      hit.point,
+      orientation,
+      decalSize,
+    );
+    const decalMaterial = new THREE.MeshStandardMaterial({
+      color: 0xff0000,
+      transparent: true,
+      depthTest: false,
+      polygonOffset: true,
+      polygonOffsetFactor: -4,
+      opacity: 0.8,
+    });
+    decalMesh = new THREE.Mesh(decalGeometry, decalMaterial);
+    decalMesh.scale.x = params.width;
+    decalMesh.scale.y = params.height;
+    decalMesh.rotation.z = params.rotation;
+    scene.add(decalMesh);
+    updateFromUI();
+  }
 });
-
 
 // Animation Loop
 function animate() {
-    requestAnimationFrame(animate);
-    controls.update();
-    renderer.render(scene, camera);
+  requestAnimationFrame(animate);
+  controls.update();
+  renderer.render(scene, camera);
 }
 animate();

--- a/tattoo-app/style.css
+++ b/tattoo-app/style.css
@@ -3,10 +3,15 @@ body {
   overflow: hidden;
 }
 
-#canvas-container {
-  position: relative;
-  width: 100%;
+/* Layout */
+.layout {
+  display: flex;
   height: 100vh;
+}
+
+#canvas-container {
+  flex: 7;
+  position: relative;
 }
 
 #c {
@@ -15,3 +20,22 @@ body {
   display: block;
 }
 
+#control-panel {
+  flex: 3;
+  padding: 1rem;
+  background: #f8f8f8;
+  box-shadow: -2px 0 5px rgba(0, 0, 0, 0.1);
+  font-family: sans-serif;
+}
+
+#control-panel h2 {
+  margin-top: 0;
+  font-size: 1.2rem;
+  color: #333;
+}
+
+#control-panel label {
+  display: block;
+  margin-bottom: 1rem;
+  color: #333;
+}


### PR DESCRIPTION
## Summary
- switch to a two-column layout with a dedicated control panel
- style the panel using a basic design system
- replace the temporary lil-gui interface with HTML controls
- document the layout change in the README
- build to verify Vite setup

## Testing
- `npx prettier --write README.md tattoo-app/index.html tattoo-app/style.css tattoo-app/main.js`
- `npm install` within `tattoo-app`
- `npm run build` within `tattoo-app`


------
https://chatgpt.com/codex/tasks/task_e_6871d61bf7008323a5bac181a0d2fd5b