### PR TITLE
Add preview grid and properties header

### DIFF
--- a/tattoo-app/index.html
+++ b/tattoo-app/index.html
@@ -13,7 +13,8 @@
         <canvas id="c"></canvas>
       </div>
       <div id="control-panel" class="panel">
-        <h2>Controls</h2>
+        <canvas id="preview" width="200" height="200"></canvas>
+        <h2>Properties</h2>
         <label
           >Width
           <input
@@ -55,7 +56,6 @@
             value="0"
           />
         </label>
-        <canvas id="preview" width="200" height="200"></canvas>
       </div>
     </div>
     <script type="module" src="/main.js"></script>

--- a/tattoo-app/src/ui/controlPanel.js
+++ b/tattoo-app/src/ui/controlPanel.js
@@ -22,6 +22,26 @@ export function initControlPanel() {
 
   function updatePreview(s) {
     ctx.clearRect(0, 0, preview.width, preview.height);
+
+    // draw subtle grid background
+    ctx.save();
+    ctx.strokeStyle = "#e0e0e0";
+    ctx.lineWidth = 1;
+    const spacing = 0.01 * PREVIEW_SCALE; // 1 cm grid
+    for (let x = spacing; x < preview.width; x += spacing) {
+      ctx.beginPath();
+      ctx.moveTo(x, 0);
+      ctx.lineTo(x, preview.height);
+      ctx.stroke();
+    }
+    for (let y = spacing; y < preview.height; y += spacing) {
+      ctx.beginPath();
+      ctx.moveTo(0, y);
+      ctx.lineTo(preview.width, y);
+      ctx.stroke();
+    }
+    ctx.restore();
+
     ctx.save();
     ctx.translate(preview.width / 2, preview.height / 2);
     ctx.rotate(s.rotation);

--- a/tattoo-app/style.css
+++ b/tattoo-app/style.css
@@ -50,5 +50,5 @@ body {
   border: 1px solid #ccc;
   background: #fff;
   display: block;
-  margin-top: 1rem;
+  margin-bottom: 1rem;
 }


### PR DESCRIPTION
## Summary
- add **Properties** section to control panel
- move preview to the top of the panel and draw a subtle grid

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6871e179336c8323a85f8faa83117869