### PR TITLE
Add image upload support for custom decals

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The journey to a new tattoo should be exciting, but the initial consultation is 
 - **Real-time Design Controls:** Use a simple and clean UI to instantly adjust the placeholder's:
   - **Width & Height:** To get the scale just right.
   - **Rotation:** To match the flow of the body.
+- **Custom Image Decal:** Upload a PNG or JPG to preview your own artwork on the model.
 - **Export Your Vision:** With a single click, save the final placement as a high-quality PNG image, perfect for attaching to a booking form or email.
 
 ## Technology

--- a/tattoo-app/index.html
+++ b/tattoo-app/index.html
@@ -14,6 +14,10 @@
       </div>
       <div id="control-panel" class="panel">
         <canvas id="preview" width="200" height="200"></canvas>
+        <label>
+          Upload Image
+          <input type="file" id="image-upload" accept="image/png, image/jpeg" />
+        </label>
         <h2>Properties</h2>
         <label
           >Width

--- a/tattoo-app/src/interaction/decalPlacement.js
+++ b/tattoo-app/src/interaction/decalPlacement.js
@@ -99,14 +99,21 @@ export function initInteraction(scene, camera, dom) {
       decalSize,
     );
 
-    const material = new THREE.MeshStandardMaterial({
-      color: 0xff0000,
+    const materialParams = {
       transparent: true,
       depthTest: false,
       polygonOffset: true,
       polygonOffsetFactor: -4,
-      opacity: 0.8,
-    });
+      opacity: s.image ? 1 : 0.8,
+    };
+    if (s.image) {
+      const texture = new THREE.Texture(s.image);
+      texture.needsUpdate = true;
+      materialParams.map = texture;
+    } else {
+      materialParams.color = 0xff0000;
+    }
+    const material = new THREE.MeshStandardMaterial(materialParams);
 
     if (decalMesh) scene.remove(decalMesh);
     decalMesh = new THREE.Mesh(geometry, material);

--- a/tattoo-app/src/ui/controlPanel.js
+++ b/tattoo-app/src/ui/controlPanel.js
@@ -17,6 +17,7 @@ export function initControlPanel() {
   const heightIn = document.getElementById("height-inch");
   const heightCm = document.getElementById("height-cm");
   const preview = document.getElementById("preview");
+  const imageInput = document.getElementById("image-upload");
 
   const ctx = preview.getContext("2d");
 
@@ -45,11 +46,16 @@ export function initControlPanel() {
     ctx.save();
     ctx.translate(preview.width / 2, preview.height / 2);
     ctx.rotate(s.rotation);
-    ctx.fillStyle = "#ff0000";
-    ctx.globalAlpha = 0.8;
     const w = s.width * PREVIEW_SCALE;
     const h = s.height * PREVIEW_SCALE;
-    ctx.fillRect(-w / 2, -h / 2, w, h);
+    if (s.image) {
+      ctx.globalAlpha = 1;
+      ctx.drawImage(s.image, -w / 2, -h / 2, w, h);
+    } else {
+      ctx.fillStyle = "#ff0000";
+      ctx.globalAlpha = 0.8;
+      ctx.fillRect(-w / 2, -h / 2, w, h);
+    }
     ctx.restore();
   }
 
@@ -73,6 +79,20 @@ export function initControlPanel() {
     setState({ width: widthM, height: heightM });
   }
 
+  function onImageUpload() {
+    const file = imageInput.files?.[0];
+    if (!file) return;
+    if (!["image/png", "image/jpeg"].includes(file.type)) return;
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      const img = new Image();
+      img.onload = () => setState({ image: img });
+      img.src = reader.result;
+    };
+    reader.readAsDataURL(file);
+  }
+
   widthSlider.addEventListener("input", onInput);
   heightSlider.addEventListener("input", onInput);
   rotationSlider.addEventListener("input", onInput);
@@ -80,6 +100,7 @@ export function initControlPanel() {
   widthCm.addEventListener("change", onUnitInput);
   heightIn.addEventListener("change", onUnitInput);
   heightCm.addEventListener("change", onUnitInput);
+  imageInput.addEventListener("change", onImageUpload);
 
   subscribe((s) => {
     widthSlider.value = s.width.toFixed(2);

--- a/tattoo-app/src/utils/state.js
+++ b/tattoo-app/src/utils/state.js
@@ -12,6 +12,8 @@ export const state = {
   anchorPosition: null,
   /** @type {import('three').Vector3|null} */
   anchorNormal: null,
+  /** @type {HTMLImageElement|null} */
+  image: null,
 };
 
 const subscribers = new Set();


### PR DESCRIPTION
## Summary
- allow user-uploaded images for tattoo decals
- update preview drawing logic for images
- generate textures from uploaded images for decal material
- document the new feature in README

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6872a53cecc88323b564abce64db957e