### PR TITLE
Fix decal projection artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This tool is built with modern, lightweight web technologies to ensure it is fas
 - **Application Logic:** Vanilla JavaScript (ESM)
 - **Build Tooling:** [Vite](https://vitejs.dev/)
 - **Decal Projection:** Using Three.js `DecalGeometry` to wrap decals onto the body mesh.
+- **Surface Filtering:** Custom utility filters decal geometry by face angle to minimize stretching on complex parts of the model.
 
 ## Getting Started
 

--- a/tattoo-app/src/interaction/decalPlacement.js
+++ b/tattoo-app/src/interaction/decalPlacement.js
@@ -2,6 +2,7 @@ import * as THREE from "three";
 import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
 import { DecalGeometry } from "three/examples/jsm/geometries/DecalGeometry.js";
 import { state, setState, subscribe } from "../utils/state.js";
+import { filterSharpAngles } from "../utils/decalUtils.js";
 
 let decalMesh; // current decal
 let anchorHelper; // visualizes hit normal
@@ -92,18 +93,23 @@ export function initInteraction(scene, camera, dom) {
     orientation.z += s.rotation;
 
     const decalSize = new THREE.Vector3(s.width, s.height, 0.1);
-    const geometry = new DecalGeometry(
+    let geometry = new DecalGeometry(
       targetMesh,
       s.anchorPosition.clone(),
       orientation,
       decalSize,
     );
 
+    const projectorNormal = s.anchorNormal.clone().normalize();
+    const MAX_SURFACE_ANGLE = Math.PI / 4; // 45 degrees
+    geometry = filterSharpAngles(geometry, projectorNormal, MAX_SURFACE_ANGLE);
+
     const materialParams = {
       transparent: true,
       depthTest: false,
       polygonOffset: true,
       polygonOffsetFactor: -4,
+      polygonOffsetUnits: 1,
       opacity: s.image ? 1 : 0.8,
     };
     if (s.image) {

--- a/tattoo-app/src/utils/decalUtils.js
+++ b/tattoo-app/src/utils/decalUtils.js
@@ -1,0 +1,56 @@
+import * as THREE from "three";
+
+/**
+ * Filter triangles in a decal geometry that exceed a given angle from the projector normal.
+ * @param {THREE.BufferGeometry} geometry original decal geometry
+ * @param {THREE.Vector3} projectorNormal orientation normal of the decal projector
+ * @param {number} maxAngle maximum allowed angle in radians
+ * @returns {THREE.BufferGeometry} filtered geometry
+ */
+export function filterSharpAngles(geometry, projectorNormal, maxAngle) {
+  const posAttr = geometry.getAttribute("position");
+  const normAttr = geometry.getAttribute("normal");
+  const uvAttr = geometry.getAttribute("uv");
+
+  if (!normAttr) return geometry;
+
+  const positions = [];
+  const normals = [];
+  const uvs = [];
+
+  const tmpNormal = new THREE.Vector3();
+
+  for (let i = 0; i < posAttr.count; i += 3) {
+    tmpNormal.fromBufferAttribute(normAttr, i);
+    if (tmpNormal.angleTo(projectorNormal) <= maxAngle) {
+      for (let j = 0; j < 3; j++) {
+        positions.push(
+          posAttr.getX(i + j),
+          posAttr.getY(i + j),
+          posAttr.getZ(i + j),
+        );
+        normals.push(
+          normAttr.getX(i + j),
+          normAttr.getY(i + j),
+          normAttr.getZ(i + j),
+        );
+        if (uvAttr) {
+          uvs.push(uvAttr.getX(i + j), uvAttr.getY(i + j));
+        }
+      }
+    }
+  }
+
+  const filtered = new THREE.BufferGeometry();
+  filtered.setAttribute(
+    "position",
+    new THREE.Float32BufferAttribute(positions, 3),
+  );
+  filtered.setAttribute("normal", new THREE.Float32BufferAttribute(normals, 3));
+  if (uvs.length) {
+    filtered.setAttribute("uv", new THREE.Float32BufferAttribute(uvs, 2));
+  }
+  filtered.computeBoundingSphere();
+  filtered.computeBoundingBox();
+  return filtered;
+}


### PR DESCRIPTION
## Summary
- filter decal triangles by angle to avoid stretching
- offset decals slightly to stop z-fighting
- document surface filtering utility

## Testing
- `npm install`
- `npx prettier --write .`

------
https://chatgpt.com/codex/tasks/task_e_6873085c0034832392e0f9b1c6f187e5