### PR TITLE
Implement shader-based decal projection

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ This tool is built with modern, lightweight web technologies to ensure it is fas
 - **Core Rendering:** [Three.js](https://threejs.org/)
 - **Application Logic:** Vanilla JavaScript (ESM)
 - **Build Tooling:** [Vite](https://vitejs.dev/)
-- **Dynamic Texture Painting:** Decals are stamped directly onto a `CanvasTexture` using UV coordinates.
-- **Surface Filtering:** Custom utility filters decal geometry by face angle to minimize stretching on complex parts of the model.
+- **Projective Decals:** Decals are projected in 3D space using the MIT-licensed `@lume/three-projected-material` library for a seamless look.
+- **Surface Filtering:** Custom utilities minimize stretching on complex parts of the model.
 
 ## Getting Started
 

--- a/tattoo-app/main.js
+++ b/tattoo-app/main.js
@@ -1,13 +1,13 @@
 import { initScene } from "./src/core/scene.js";
 import { initControlPanel } from "./src/ui/controlPanel.js";
-import { initTexturePainter } from "./src/interaction/texturePainter.js";
+import { initProjector } from "./src/interaction/projector.js";
 
 const canvas = document.querySelector("#c");
 const container = document.getElementById("canvas-container");
 const { scene, camera, renderer, controls } = initScene(canvas, container);
 
 initControlPanel();
-initTexturePainter(scene, camera, renderer.domElement);
+initProjector(scene, camera, renderer.domElement);
 
 function animate() {
   requestAnimationFrame(animate);

--- a/tattoo-app/package-lock.json
+++ b/tattoo-app/package-lock.json
@@ -8,6 +8,7 @@
       "name": "tattoo-app",
       "version": "0.0.0",
       "dependencies": {
+        "@lume/three-projected-material": "^0.4.0",
         "lil-gui": "^0.18.2",
         "three": "^0.178.0"
       },
@@ -456,6 +457,15 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@lume/three-projected-material": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@lume/three-projected-material/-/three-projected-material-0.4.0.tgz",
+      "integrity": "sha512-ubj2LCql/SfYKUIDItHXpdUzk2rQ7GyJMRTWoR4aM0IQSYwiA0jPhq5qVDiCm/P41hzpuUDbfXJpsWZL8rIZRQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.152.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {

--- a/tattoo-app/package.json
+++ b/tattoo-app/package.json
@@ -13,6 +13,7 @@
     "vite": "^7.0.4"
   },
   "dependencies": {
+    "@lume/three-projected-material": "^0.4.0",
     "lil-gui": "^0.18.2",
     "three": "^0.178.0"
   }

--- a/tattoo-app/src/interaction/projector.js
+++ b/tattoo-app/src/interaction/projector.js
@@ -1,0 +1,115 @@
+import * as THREE from "three";
+import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
+import { ProjectedMaterial } from "@lume/three-projected-material/dist/ProjectedMaterial.js";
+import { state, setState, subscribe } from "../utils/state.js";
+
+/**
+ * Convert pointer coordinates to normalized device coordinates relative to an element.
+ * @param {PointerEvent} event pointer event
+ * @param {HTMLElement} element element to measure offset from
+ * @param {THREE.Vector2} out vector to store normalized coordinates
+ * @returns {void}
+ */
+function getNormalizedPointer(event, element, out) {
+  const rect = element.getBoundingClientRect();
+  out.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+  out.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+}
+
+/**
+ * Initialize shader-based projective decal interaction.
+ * @param {THREE.Scene} scene scene to add the model to
+ * @param {THREE.Camera} camera camera used for raycasting
+ * @param {HTMLElement} dom DOM element to attach events to
+ * @returns {void}
+ */
+export function initProjector(scene, camera, dom) {
+  const raycaster = new THREE.Raycaster();
+  const mouse = new THREE.Vector2();
+
+  let model;
+  let targetMesh;
+  let projector;
+
+  const loader = new GLTFLoader();
+  loader.load(
+    "/assets/model.glb",
+    (gltf) => {
+      model = gltf.scene;
+      scene.add(model);
+      model.traverse((child) => {
+        if (child.isMesh) {
+          const baseMap = child.material.map || null;
+          const mat = new ProjectedMaterial({
+            camera: new THREE.OrthographicCamera(1, 1, 1, 1, 0.01, 10),
+            texture: new THREE.Texture(),
+            map: baseMap,
+            transparent: true,
+          });
+          child.material = mat;
+        }
+      });
+    },
+    undefined,
+    (err) => console.error("Model load error", err),
+  );
+
+  dom.addEventListener("pointerdown", (event) => {
+    if (!model) return;
+    getNormalizedPointer(event, dom, mouse);
+    raycaster.setFromCamera(mouse, camera);
+    const intersects = raycaster.intersectObject(model, true);
+    if (intersects.length === 0) return;
+    const hit = intersects[0];
+    targetMesh = hit.object;
+    setState({
+      anchorPosition: hit.point.clone(),
+      anchorNormal: hit.face.normal.clone(),
+    });
+  });
+
+  subscribe(applyState);
+
+  /**
+   * Apply state to update the projected decal.
+   * @param {typeof state} s
+   * @returns {void}
+   */
+  function applyState(s) {
+    if (!s.anchorPosition || !s.anchorNormal || !targetMesh) return;
+
+    if (!projector) {
+      projector = new THREE.OrthographicCamera(
+        -s.width / 2,
+        s.width / 2,
+        s.height / 2,
+        -s.height / 2,
+        0.01,
+        10,
+      );
+    } else {
+      projector.left = -s.width / 2;
+      projector.right = s.width / 2;
+      projector.top = s.height / 2;
+      projector.bottom = -s.height / 2;
+    }
+
+    projector.position
+      .copy(s.anchorPosition)
+      .addScaledVector(s.anchorNormal, 0.01);
+    projector.up.set(0, 1, 0);
+    projector.lookAt(s.anchorPosition);
+    projector.rotateZ(s.rotation);
+    projector.updateProjectionMatrix();
+
+    const material = targetMesh.material;
+    material.camera = projector;
+    if (s.image) {
+      const texture = new THREE.Texture(s.image);
+      texture.needsUpdate = true;
+      material.texture = texture;
+    }
+    material.updateFromCamera();
+    material.project(targetMesh);
+  }
+}

--- a/tattoo-app/src/utils/state.js
+++ b/tattoo-app/src/utils/state.js
@@ -8,6 +8,10 @@ export const state = {
   width: 0.2, // meters
   height: 0.2, // meters
   rotation: 0,
+  /** @type {import('three').Vector3|null} */
+  anchorPosition: null,
+  /** @type {import('three').Vector3|null} */
+  anchorNormal: null,
   /** @type {import('three').Vector2|null} */
   anchorUV: null,
   /** @type {HTMLImageElement|null} */


### PR DESCRIPTION
## Summary
- integrate @lume/three-projected-material
- add projective decal interaction module
- wire new projector in `main.js`
- extend global state with anchor position/normal
- document new decal method in README

## Testing
- `npx prettier --write .`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68732d342e548323b719fc5e9607db91